### PR TITLE
Add support for providing a TOTP key

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,11 @@ See the [openconnect documentation](https://www.infradead.org/openconnect/manual
 
 Either set the password in the `.env` file or leave the variable `OPENCONNECT_PASSWORD` unset, so you get prompted when starting up the container.
 
-Optionally set a multi factor authentication code:
+You can also use multi-factor one-time-password codes in two different ways. If your connection uses a time-based OTP (like Google Authenticator), you can provide the key, and the entrypoint will generate and provide the code whenever it tries to connect:
+
+	OPENCONNECT_TOTP_SECRET=<Key for TOTP>
+
+Otherwise, you can generate the one-time-password yourself and pass it when you start the server:
 
 	OPENCONNECT_MFA_CODE=<Multi factor authentication code>
 

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine:edge
-MAINTAINER Wolfgang Klinger <wolfgang@wazum.com>
+LABEL org.opencontainers.image.authors="Wolfgang Klinger <wolfgang@wazum.com>"
 
 RUN apk add --no-cache libcrypto1.1 libssl1.1 libstdc++ --repository http://dl-cdn.alpinelinux.org/alpine/edge/main
 RUN apk add --no-cache oath-toolkit-libpskc --repository http://dl-cdn.alpinelinux.org/alpine/edge/community
@@ -18,10 +18,10 @@ RUN apk add --no-cache ca-certificates wget \
     && make \
     && make install \
     # add vpn-slice with dependencies (dig) https://github.com/dlenski/vpn-slice
-    && apk add --no-cache python3 bind-tools && pip3 install --upgrade pip \
-    && pip3 install https://github.com/dlenski/vpn-slice/archive/master.zip \
-    # always add the docker DNS server
-    && grep -qxF 'nameserver 127.0.0.11' /etc/resolv.conf || echo 'nameserver 127.0.0.11' >> /etc/resolv.conf \
+    && apk add --no-cache python3-dev py3-pip bind-tools && pip3 install --upgrade pip \
+    && pip3 install vpn-slice \
+    # get totp tool
+    && apk add oath-toolkit-oathtool \
     && apk del .build-deps wget
 
 # Use an up-to-date version of vpnc-script

--- a/build/entrypoint.sh
+++ b/build/entrypoint.sh
@@ -13,6 +13,10 @@ run () {
   elif [[ ! -z "${OPENCONNECT_PASSWORD}" ]] && [[ ! -z "${OPENCONNECT_MFA_CODE}" ]]; then
   # Multi factor authentication (MFA)
     (echo $OPENCONNECT_PASSWORD; echo $OPENCONNECT_MFA_CODE) | openconnect -u $OPENCONNECT_USER $OPENCONNECT_OPTIONS --passwd-on-stdin $OPENCONNECT_URL
+  elif [[ ! -z "${OPENCONNECT_PASSWORD}" ]] && [[ ! -z "${OPENCONNECT_TOTP_SECRET}" ]]; then
+  # Time-based One Time Password (TOTP, "Google Authenticator")
+    OPENCONNECT_TOTP=$(oathtool -b --totp "$OPENCONNECT_TOTP_SECRET")
+    echo -e "$OPENCONNECT_PASSWORD\n$OPENCONNECT_TOTP\n" | openconnect -u $OPENCONNECT_USER $OPENCONNECT_OPTIONS --passwd-on-stdin $OPENCONNECT_URL
   elif [[ ! -z "${OPENCONNECT_PASSWORD}" ]]; then
   # Standard authentication
     echo $OPENCONNECT_PASSWORD | openconnect -u $OPENCONNECT_USER $OPENCONNECT_OPTIONS --passwd-on-stdin $OPENCONNECT_URL


### PR DESCRIPTION
* Add ability to provide a TOTP secret key, with entrypoint generating the TOTP for each connection (rather than having to pass the actual key on startup)
* Some fixes to the Dockerfile for broken dependencies
* Add documentation for TOTP support